### PR TITLE
Avoiding std::swap() in move assignment to make the intent more clear

### DIFF
--- a/Gyak05/01-AvlTreeCopyMoveProfiling/avltree.cpp
+++ b/Gyak05/01-AvlTreeCopyMoveProfiling/avltree.cpp
@@ -57,9 +57,11 @@ AvlTree& AvlTree::operator=(const AvlTree& other) {
 }
 
 AvlTree& AvlTree::operator=(AvlTree&& other) {
-	std::cout << "move assignment called.. calling swap" << std::endl;
-	std::swap(root, other.root);
-	std::cout << "swap ended in move ass." << std::endl;
+	std::cout << "move assignment called.." << std::endl;
+        delete root;
+        root = other.root;
+        other.root = nullptr;
+	std::cout << "move ass. finished" << std::endl;
 	return *this;
 }
 


### PR DESCRIPTION
Delete all the contents of other. It's still safe to decontruct it
as deleting a nullptr is a safe operation

According to tests, this also leads to certain performance gain.
Depending on the test cases somewhere between 5 and 50% which is
too vague. We have to better understand what's the reason of the huge
difference.